### PR TITLE
run rakudo-moar in a restricted firejail

### DIFF
--- a/Vagrant.sh
+++ b/Vagrant.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list
+
+
+apt-get -y update
+apt-get -y install build-essential git cpanminus
+
+apt-get -y install firejail --no-install-recommends
+apt-get -y install default-jdk --no-install-recommends
+
+apt-get -y -t stretch-backports install firejail
+
+ln -s /home/vagrant /home/camelia
+ln -s /vagrant /home/vagrant/evalbot
+
+
+apt-get -y intstall libbot-basicbot-perl libconfig-file-perl libbsd-resource-perl libjson-perl
+cpanm IRC/FromANSI/Tiny.pm
+
+sudo -uvagrant -c "mkdir ~/log"
+

--- a/Vagrant.sh
+++ b/Vagrant.sh
@@ -6,17 +6,13 @@ echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/source
 apt-get -y update
 apt-get -y install build-essential git cpanminus
 
-apt-get -y install firejail --no-install-recommends
 apt-get -y install default-jdk --no-install-recommends
 
-apt-get -y -t stretch-backports install firejail
-
-ln -s /home/vagrant /home/camelia
-ln -s /vagrant /home/vagrant/evalbot
+apt-get -y -t stretch-backports install firejail --no-install-recommends
 
 
 apt-get -y intstall libbot-basicbot-perl libconfig-file-perl libbsd-resource-perl libjson-perl
 cpanm IRC/FromANSI/Tiny.pm
 
-sudo -uvagrant -c "mkdir ~/log"
+
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,4 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "debian/stretch64"
+  config.vm.provision :shell, path: "Vagrant.sh"
+end

--- a/evalbot.pl
+++ b/evalbot.pl
@@ -82,7 +82,7 @@ package Evalbot;
     our %impls = (
             'rakudo-moar' => {
                 chdir       => "$home",
-                cmd_line    => './rakudo-m-inst/bin/perl6-m --setting=RESTRICTED %program',
+                cmd_line    => 'firejail --private --caps.drop=all --cpu=0 --nosound --novideo --net=none --nodbus --noroot --private-tmp --seccomp --quiet --timeout=00:00:30 --x11=none -c ./rakudo-m-inst/bin/perl6-m --setting=RESTRICTED %program',
                 nolock      => 1,
                 revision    => sub { get_revision_from_file("$home/rakudo-m-inst/revision")},
             },

--- a/evalbot.pl
+++ b/evalbot.pl
@@ -58,81 +58,16 @@ package Evalbot;
     my $max_output_len = 290;
 
     my %aliases = (
-        master  => ['rakudo-moar'],
-        rakudo  => ['rakudo-moar'],
-        r       => ['rakudo-moar', 'rakudo-jvm'],
-        'r-m'   => 'rakudo-moar',
-        'rm'    => 'rakudo-moar',
-        m       => 'rakudo-moar',
         p6  => [qw/rakudo-moar/],
-        perl6  => [qw/rakudo-moar rakudo-jvm/],
-        nqp => [qw/nqp-moarvm/],
-        'nqp-m'   => 'nqp-moarvm',
-        'nqp-mvm' => 'nqp-moarvm',
-        'nqp-q'   => 'nqp-js',
-        'r-jvm'   => 'rakudo-jvm',
-        'r-j'     => 'rakudo-jvm',
-        'rj'      => 'rakudo-jvm',
-        'j'       => 'rakudo-jvm',
-        'p56'     => 'p5-to-p6',
-        star      => 'star-m',
-        sm        => 'star-m',
     );
 
     our %impls = (
             'rakudo-moar' => {
                 chdir       => "$home",
-                cmd_line    => 'firejail --private --caps.drop=all --cpu=0 --nosound --novideo --net=none --nodbus --noroot --private-tmp --seccomp --quiet --timeout=00:00:30 --x11=none -c ./rakudo-m-inst/bin/perl6-m --setting=RESTRICTED %program',
+                cmd_line    => 'firejail --nonewprivs --noroot --whitelist=%program --caps.drop=all --seccomp --quiet --net=none --read-only=/ --private --private-tmp --private-dev --read-only=/home --rlimit-fsize=52428800 --rlimit-nproc=30 --rlimit-cpu=2 --read-only=/opt --read-only=/var --private-etc=group,hostname,localtime,nsswitch.conf,passwd,resolv.conf -c /opt/rakudo-m-inst-1/bin/perl6-m --setting=RESTRICTED %program',
                 nolock      => 1,
-                revision    => sub { get_revision_from_file("$home/rakudo-m-inst/revision")},
+                revision    => sub { get_revision_from_file("/opt/rakudo-m-inst-1/revision")},
             },
-            'prof-m' => {
-                chdir       => "$home",
-                cmd_line    => './rakudo-inst/bin/perl6-m --profile --profile-filename=/tmp/mprof.html --setting=RESTRICTED %program',
-                nolock      => 1,
-                revision    => sub { get_revision_from_file("$home/rakudo-inst/revision")},
-                post        => sub {
-                    my ($output) = @_;
-                    my $destfile = sprintf "%x", time - 1420066800; # seconds since 2015-01-01
-                    print "\nnow running scp...\n";
-                    system("scp", '-q', '/tmp/mprof.html', "p.p6c.org\@www.p6c.org:public/$destfile.html");
-                    return ('Prof' => "http://p.p6c.org/$destfile");
-                },
-            },
-            'star-m' => {
-                chdir       => "$home/star/",
-                cmd_line    => './bin/perl6-m --setting=RESTRICTED %program',
-                revision    => sub { get_revision_from_file("$home/star/version") },
-            },
-            'nqp-jvm'    => {
-                chdir       => $home,
-                cmd_line    => './rakudo-j-inst/bin/nqp-j %program',
-            },
-            'nqp-moarvm' => {
-                chdir       => $home,
-                cmd_line    => './rakudo-m-inst/bin/nqp-m %program',
-            },
-            'nqp-js'     => {
-                chdir       => "$home/nqp-js",
-                cmd_line    => './nqp-js %program',
-            },
-            'rakudo-jvm' => {
-                chdir       => $home,
-                cmd_line    => "$^X $home/rakudo-j-inst/bin/eval-client.pl $home/p6eval-token run_limited 15  %program",
-                revision    => sub { get_revision_from_file("$home/rakudo-j-inst/revision")},
-            },
-            'p5-to-p6' => {
-                chdir       => "$home/Perlito",
-                cmd_line    => "perl perlito5.pl --noboilerplate -I./src5/lib -Cperl6 %program",
-                revision    => sub {
-                    my $r = qx/cd $home && Perlito && git describe/;
-                    chomp $r;
-                    return $r;
-                },
-            },
-            'debug-cat' => {
-                cmd_line => 'cat %program',
-            }
     );
 
     my $evalbot_version = get_revision();

--- a/firejail.md
+++ b/firejail.md
@@ -1,0 +1,3 @@
+# firejail notes
+
+firejail --private --caps.drop=all --cpu=0 --nosound --novideo --net=none --nodbus --noroot --private-tmp --seccomp --quiet --timeout=00:00:30 --x11=none -c perl6 -e 'say "/tmp".IO.dir;say qx|curl -s https://ifconfig.co;|;say qx|ip a|';

--- a/freenode.org.conf
+++ b/freenode.org.conf
@@ -1,5 +1,4 @@
 server    = irc.freenode.org
-channels  = perl6 perl6-toolchain swhack perl-kr rosettacode moarvm learnprogramming perl6-dev zofbot
-nick      = camelia
-alt_nicks = p6eval p6_eval
-pass      = WFkuDV17A6Jhj
+channels  = c4meli4
+nick      = c4meli4
+alt_nicks = c4meli4_

--- a/freenode.org.conf
+++ b/freenode.org.conf
@@ -1,4 +1,4 @@
 server    = irc.freenode.org
-channels  = c4meli4
+channels  = oslohackerspace
 nick      = c4meli4
 alt_nicks = c4meli4_


### PR DESCRIPTION
An attempt to make evalbot run rakudo-moar in an very restricted environment.

- No network access
- Ephemeral private  /tmp, /var, /etc, /home, etc mounts
- Resource limits like cpu time
- Drops all linux capabilities

Work in progress, only supports p6 at this time. Runs as c4meli4 on freenode/#oslohackerspace:
